### PR TITLE
Refactor mobile theme button to be low profile and remove outline

### DIFF
--- a/components/ui/mobile-menu.tsx
+++ b/components/ui/mobile-menu.tsx
@@ -157,10 +157,10 @@ export function MobileMenu({ isOpen, onOpenChange }: MobileMenuProps) {
                   Theme
                 </span>
                 <Button
-                  variant="outline"
+                  variant="ghost"
                   size="sm"
                   onClick={toggleTheme}
-                  className="h-10 px-3"
+                  className="h-8 px-2 hover:bg-zinc-100 dark:hover:bg-zinc-800"
                   aria-label={`Switch to ${theme === "light" ? "dark" : "light"} theme`}
                 >
                   {theme === "light" ? (


### PR DESCRIPTION
- Changed variant from 'outline' to 'ghost' to remove border
- Reduced height from h-10 to h-8 for lower profile appearance
- Reduced padding from px-3 to px-2 for more compact design
- Added subtle hover states that match design language

🤖 Generated with [Claude Code](https://claude.com/claude-code)