### PR TITLE
fix(theme): define shadcn design tokens; addvanced feedback + shared Related Projects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -310,3 +310,11 @@ logo-bar*.png
 nagarro-cell.png
 waffle-card.png
 waffle-gallery.png
+before-*.png
+after-*.png
+ba-*.png
+item*.png
+cta-*.png
+addv-*.png
+addvanced-feedback-*.png
+addvanced-recheck-*.png

--- a/__tests__/projects/waffle/waffle-grid-card.test.tsx
+++ b/__tests__/projects/waffle/waffle-grid-card.test.tsx
@@ -1,6 +1,8 @@
 import { render, screen } from "@testing-library/react";
 import ProjectsClient from "@/app/projects/projects-client";
 import { PROJECTS } from "@/lib/data/projects";
+import { existsSync } from "fs";
+import { join } from "path";
 
 // motion/react is globally mocked via jest.config.js moduleNameMapper
 // (__mocks__/motion/react.js) — no inline mock needed here.
@@ -28,9 +30,14 @@ describe("Waffle grid card — data shape", () => {
     expect(waffle?.name).toBe("Waffle");
   });
 
-  it("the waffle entry has thumbnail === '/projects/waffle/screenshot.png'", () => {
+  it("the waffle entry's thumbnail is the app dashboard and the file exists", () => {
     const waffle = PROJECTS.find((p) => p.slug === "waffle");
-    expect(waffle?.thumbnail).toBe("/projects/waffle/screenshot.png");
+    // Was screenshot.png — a marketing mock. Randy swapped it for the real
+    // signed-in dashboard on 2026-08-16; the grid card should show the product.
+    expect(waffle?.thumbnail).toBe("/projects/waffle/dashboard.png");
+    expect(existsSync(join(process.cwd(), "public", waffle!.thumbnail!))).toBe(
+      true,
+    );
   });
 
   it("the waffle entry has a non-empty longDescription", () => {

--- a/app/globals.css
+++ b/app/globals.css
@@ -2,6 +2,85 @@
 @plugin '@tailwindcss/typography';
 @custom-variant dark (&:is(.dark *));
 
+/*
+  Design tokens for the shadcn/ui components (Button, Card, Badge, Tabs, …).
+
+  These were never defined. tailwind.config.js maps `primary` → hsl(var(--primary))
+  and so on, but Tailwind v4 does not load that file, and the --primary /
+  --muted / --accent variables themselves existed nowhere — so `bg-primary`,
+  `bg-muted`, `text-muted-foreground`, `bg-accent`, `bg-card` etc. generated
+  no CSS at all. Primary buttons had no fill, badges were plain text, and
+  hover:bg-accent was a no-op.
+
+  Values are the shadcn "zinc" preset, chosen to sit alongside the zinc
+  utilities the rest of the site is hand-written in.
+*/
+:root {
+  --background: oklch(1 0 0);
+  --foreground: oklch(0.141 0.005 285.823);
+  --card: oklch(1 0 0);
+  --card-foreground: oklch(0.141 0.005 285.823);
+  --popover: oklch(1 0 0);
+  --popover-foreground: oklch(0.141 0.005 285.823);
+  --primary: oklch(0.21 0.006 285.885);
+  --primary-foreground: oklch(0.985 0 0);
+  --secondary: oklch(0.967 0.001 286.375);
+  --secondary-foreground: oklch(0.21 0.006 285.885);
+  --muted: oklch(0.967 0.001 286.375);
+  --muted-foreground: oklch(0.552 0.016 285.938);
+  --accent: oklch(0.967 0.001 286.375);
+  --accent-foreground: oklch(0.21 0.006 285.885);
+  --destructive: oklch(0.577 0.245 27.325);
+  --destructive-foreground: oklch(0.985 0 0);
+  --border: oklch(0.92 0.004 286.32);
+  --input: oklch(0.92 0.004 286.32);
+  --ring: oklch(0.705 0.015 286.067);
+}
+
+.dark {
+  --background: oklch(0.141 0.005 285.823);
+  --foreground: oklch(0.985 0 0);
+  --card: oklch(0.21 0.006 285.885);
+  --card-foreground: oklch(0.985 0 0);
+  --popover: oklch(0.21 0.006 285.885);
+  --popover-foreground: oklch(0.985 0 0);
+  --primary: oklch(0.92 0.004 286.32);
+  --primary-foreground: oklch(0.21 0.006 285.885);
+  --secondary: oklch(0.274 0.006 286.033);
+  --secondary-foreground: oklch(0.985 0 0);
+  --muted: oklch(0.274 0.006 286.033);
+  --muted-foreground: oklch(0.705 0.015 286.067);
+  --accent: oklch(0.274 0.006 286.033);
+  --accent-foreground: oklch(0.985 0 0);
+  --destructive: oklch(0.704 0.191 22.216);
+  --destructive-foreground: oklch(0.985 0 0);
+  --border: oklch(1 0 0 / 10%);
+  --input: oklch(1 0 0 / 15%);
+  --ring: oklch(0.552 0.016 285.938);
+}
+
+@theme inline {
+  --color-background: var(--background);
+  --color-foreground: var(--foreground);
+  --color-card: var(--card);
+  --color-card-foreground: var(--card-foreground);
+  --color-popover: var(--popover);
+  --color-popover-foreground: var(--popover-foreground);
+  --color-primary: var(--primary);
+  --color-primary-foreground: var(--primary-foreground);
+  --color-secondary: var(--secondary);
+  --color-secondary-foreground: var(--secondary-foreground);
+  --color-muted: var(--muted);
+  --color-muted-foreground: var(--muted-foreground);
+  --color-accent: var(--accent);
+  --color-accent-foreground: var(--accent-foreground);
+  --color-destructive: var(--destructive);
+  --color-destructive-foreground: var(--destructive-foreground);
+  --color-border: var(--border);
+  --color-input: var(--input);
+  --color-ring: var(--ring);
+}
+
 /* Motion and interaction utilities */
 @utility motion-safe {
   @media (prefers-reduced-motion: no-preference) {

--- a/app/projects/[slug]/page.tsx
+++ b/app/projects/[slug]/page.tsx
@@ -84,10 +84,6 @@ export default async function ProjectDetailPage({
     notFound();
   }
 
-  const relatedProjects = PROJECTS.filter(
-    (p) => p.id !== project.id && p.category === project.category,
-  ).slice(0, 2);
-
   return (
     <>
       <CreativeWorkStructuredData
@@ -107,10 +103,7 @@ export default async function ProjectDetailPage({
         role={project.role}
       />
       <ProjectFAQStructuredData projectSlug={project.slug} />
-      <ProjectDetailClient
-        project={project}
-        relatedProjects={relatedProjects}
-      />
+      <ProjectDetailClient project={project} />
     </>
   );
 }

--- a/app/projects/[slug]/project-detail-client.tsx
+++ b/app/projects/[slug]/project-detail-client.tsx
@@ -14,13 +14,7 @@ import {
   Cloud,
   Cpu,
 } from "lucide-react";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
@@ -29,12 +23,9 @@ import { CaseStudyTOC } from "@/components/case-study/case-study-toc";
 import { DecisionCallout } from "@/components/case-study/decision-callout";
 import { ReflectionBlock } from "@/components/case-study/reflection-block";
 import { RoleNarrativeSection } from "@/components/case-study/role-narrative-section";
+import { RelatedProjects } from "@/components/case-study/related-projects";
 import { BreadcrumbNav } from "@/components/ui/breadcrumb-nav";
-import {
-  AnimatedVideo,
-  AnimatedImage,
-  AnimatedIframe,
-} from "@/components/ui/animated-asset";
+import { AnimatedImage } from "@/components/ui/animated-asset";
 import { VideoPlayer } from "@/components/ui/video-player";
 import {
   VimeoEmbed,
@@ -100,7 +91,6 @@ function SectionCard({
 
 interface ProjectDetailClientProps {
   project: Project;
-  relatedProjects: Project[];
 }
 
 // Helper function to determine performance level based on metric value
@@ -160,7 +150,6 @@ function groupMetrics(metrics: { label: string; value: string }[]) {
 
 export default function ProjectDetailClient({
   project,
-  relatedProjects,
 }: ProjectDetailClientProps) {
   return (
     <div className="min-h-screen">
@@ -1083,58 +1072,10 @@ export default function ProjectDetailClient({
           </motion.section>
         )}
 
-        {/* Related Projects */}
-        {relatedProjects.length > 0 && (
-          <motion.section
-            className="space-y-6"
-            variants={VARIANTS_ITEM}
-            transition={TRANSITION_ITEM}
-          >
-            <ScrambleSectionTitle as="h2" className="text-2xl font-bold">
-              Related Projects
-            </ScrambleSectionTitle>
-            <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
-              {relatedProjects.map((relatedProject) => (
-                <Card
-                  key={relatedProject.id}
-                  className="group transition-all duration-300 hover:shadow-lg"
-                >
-                  <div className="aspect-video overflow-hidden">
-                    {isVimeoUrl(relatedProject.video) ? (
-                      <AnimatedIframe
-                        src={relatedProject.video}
-                        title={`${relatedProject.name} Demo Video`}
-                        hoverScale={1.05}
-                      />
-                    ) : (
-                      <AnimatedVideo
-                        src={relatedProject.video}
-                        poster={relatedProject.thumbnail}
-                        hoverScale={1.05}
-                      />
-                    )}
-                  </div>
-                  <CardHeader>
-                    <CardTitle className="transition-colors group-hover:text-blue-600">
-                      {relatedProject.name}
-                    </CardTitle>
-                    <CardDescription>
-                      {relatedProject.description}
-                    </CardDescription>
-                  </CardHeader>
-                  <CardContent>
-                    <Link
-                      href={`/projects/${relatedProject.slug}`}
-                      className="inline-flex w-full items-center justify-center gap-2 rounded-lg bg-blue-600 px-6 py-3 text-white transition-colors hover:bg-blue-700"
-                    >
-                      View Project
-                    </Link>
-                  </CardContent>
-                </Card>
-              ))}
-            </div>
-          </motion.section>
-        )}
+        {/* Related Projects — shared component, same on every project page */}
+        <motion.div variants={VARIANTS_ITEM} transition={TRANSITION_ITEM}>
+          <RelatedProjects currentId={project.id} />
+        </motion.div>
 
         {/* Global Recommendations */}
         <motion.div variants={VARIANTS_ITEM} transition={TRANSITION_ITEM}>

--- a/app/projects/addvanced/addvanced-client.tsx
+++ b/app/projects/addvanced/addvanced-client.tsx
@@ -37,6 +37,7 @@ import { AnimatedMetricCard } from "@/components/ui/animated-metric-card";
 // Data
 import { PROJECTS } from "@/lib/data/projects";
 import { CaseStudyNarrative } from "@/components/case-study/case-study-narrative";
+import { RelatedProjects } from "@/components/case-study/related-projects";
 import { ReflectionBlock } from "@/components/case-study/reflection-block";
 
 // SpotlightCard Component (reused from existing projects)
@@ -247,14 +248,20 @@ export default function AddvancedClient() {
             Key Achievements
           </h3>
 
-          <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-4">
+          {/* Flex + centered rather than a 4-col grid: with 7 metrics a grid
+              leaves the last row left-aligned with a hole; this centres it. */}
+          <div className="flex flex-wrap justify-center gap-6">
             {metrics?.slice(0, 8).map((metric, index) => (
-              <AnimatedMetricCard
+              <div
                 key={metric.label}
-                label={metric.label}
-                value={metric.value}
-                animationDelay={index * 100}
-              />
+                className="flex w-full md:w-[calc(50%-0.75rem)] lg:w-[calc(25%-1.125rem)] [&>*]:w-full"
+              >
+                <AnimatedMetricCard
+                  label={metric.label}
+                  value={metric.value}
+                  animationDelay={index * 100}
+                />
+              </div>
             ))}
           </div>
         </div>
@@ -517,7 +524,9 @@ export default function AddvancedClient() {
                 <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-4">
                   <Card>
                     <CardContent className="p-6 text-center">
-                      <Smartphone className="text-primary mx-auto mb-4 h-8 w-8" />
+                      <div className="bg-primary/10 mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full">
+                        <Smartphone className="text-primary h-8 w-8" />
+                      </div>
                       <h4 className="mb-2 font-semibold">Reachability</h4>
                       <p className="text-muted-foreground text-sm">
                         All functions accessible within thumb-friendly zones
@@ -527,7 +536,9 @@ export default function AddvancedClient() {
 
                   <Card>
                     <CardContent className="p-6 text-center">
-                      <Shield className="text-primary mx-auto mb-4 h-8 w-8" />
+                      <div className="bg-primary/10 mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full">
+                        <Shield className="text-primary h-8 w-8" />
+                      </div>
                       <h4 className="mb-2 font-semibold">
                         Heuristic Compliance
                       </h4>
@@ -539,7 +550,9 @@ export default function AddvancedClient() {
 
                   <Card>
                     <CardContent className="p-6 text-center">
-                      <ArrowRight className="text-primary mx-auto mb-4 h-8 w-8" />
+                      <div className="bg-primary/10 mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full">
+                        <ArrowRight className="text-primary h-8 w-8" />
+                      </div>
                       <h4 className="mb-2 font-semibold">Direct Navigation</h4>
                       <p className="text-muted-foreground text-sm">
                         Minimal steps to complete core tasks
@@ -549,7 +562,9 @@ export default function AddvancedClient() {
 
                   <Card>
                     <CardContent className="p-6 text-center">
-                      <Target className="text-primary mx-auto mb-4 h-8 w-8" />
+                      <div className="bg-primary/10 mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full">
+                        <Target className="text-primary h-8 w-8" />
+                      </div>
                       <h4 className="mb-2 font-semibold">Purposeful Tasks</h4>
                       <p className="text-muted-foreground text-sm">
                         Every interaction serves strategic career advancement
@@ -622,10 +637,12 @@ export default function AddvancedClient() {
               Comprehensive Usability Testing Methodology
             </h3>
 
-            <div className="grid gap-8 md:grid-cols-2 lg:grid-cols-4">
+            <div className="grid gap-8 md:grid-cols-2">
               <Card>
                 <CardContent className="p-6 text-center">
-                  <Users className="text-primary mx-auto mb-4 h-8 w-8" />
+                  <div className="bg-primary/10 mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full">
+                    <Users className="text-primary h-8 w-8" />
+                  </div>
                   <h4 className="mb-2 font-semibold">14 Participants</h4>
                   <p className="text-muted-foreground text-sm">
                     Moderated usability testing in open lab environment
@@ -635,7 +652,9 @@ export default function AddvancedClient() {
 
               <Card>
                 <CardContent className="p-6 text-center">
-                  <BarChart3 className="text-primary mx-auto mb-4 h-8 w-8" />
+                  <div className="bg-primary/10 mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full">
+                    <BarChart3 className="text-primary h-8 w-8" />
+                  </div>
                   <h4 className="mb-2 font-semibold">4 Task Scenarios</h4>
                   <p className="text-muted-foreground text-sm">
                     Core user journeys tested via Maze platform
@@ -645,7 +664,9 @@ export default function AddvancedClient() {
 
               <Card>
                 <CardContent className="p-6 text-center">
-                  <Smartphone className="text-primary mx-auto mb-4 h-8 w-8" />
+                  <div className="bg-primary/10 mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full">
+                    <Smartphone className="text-primary h-8 w-8" />
+                  </div>
                   <h4 className="mb-2 font-semibold">Cross-Platform</h4>
                   <p className="text-muted-foreground text-sm">
                     MAC/PC devices, virtual desktop/laptop sessions
@@ -655,7 +676,9 @@ export default function AddvancedClient() {
 
               <Card>
                 <CardContent className="p-6 text-center">
-                  <Clock className="text-primary mx-auto mb-4 h-8 w-8" />
+                  <div className="bg-primary/10 mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full">
+                    <Clock className="text-primary h-8 w-8" />
+                  </div>
                   <h4 className="mb-2 font-semibold">No Time Limits</h4>
                   <p className="text-muted-foreground text-sm">
                     Natural user behavior patterns encouraged
@@ -1240,6 +1263,13 @@ export default function AddvancedClient() {
               heading="Design Leadership Reflection"
             />
           )}
+        </div>
+      </section>
+
+      {/* Related Projects */}
+      <section className="px-6 py-16 lg:px-8">
+        <div className="mx-auto max-w-6xl">
+          <RelatedProjects currentId="addvanced" />
         </div>
       </section>
 

--- a/app/projects/echo/echo-client.tsx
+++ b/app/projects/echo/echo-client.tsx
@@ -17,6 +17,7 @@ import Link from "next/link";
 import { PROJECTS } from "@/lib/data/projects";
 import { CaseStudyNarrative } from "@/components/case-study/case-study-narrative";
 import { ReflectionBlock } from "@/components/case-study/reflection-block";
+import { RelatedProjects } from "@/components/case-study/related-projects";
 
 // Get the Echo project data
 const echoProject = PROJECTS.find((p) => p.id === "echo")!;
@@ -439,6 +440,8 @@ export default function EchoClientPage() {
         reflection={enhancedProcessStory.reflection}
         heading="Product Design Leadership Reflection"
       />
+
+      <RelatedProjects currentId="echo" />
 
       {/* Navigation */}
       <section className="mb-16 border-t border-zinc-200 px-4 pt-8 sm:mb-20 sm:px-6 lg:mb-24 lg:px-8 dark:border-zinc-700">

--- a/app/projects/nagarro/nagarro-client.tsx
+++ b/app/projects/nagarro/nagarro-client.tsx
@@ -25,6 +25,7 @@ import Image from "next/image";
 import { PROJECTS } from "@/lib/data/projects";
 import { CaseStudyNarrative } from "@/components/case-study/case-study-narrative";
 import { ReflectionBlock } from "@/components/case-study/reflection-block";
+import { RelatedProjects } from "@/components/case-study/related-projects";
 import { useRef, useState, useEffect, useCallback, memo, useMemo } from "react";
 import { AnimatedNumber } from "@/components/core/animated-number";
 import { parseMetricValue } from "@/lib/utils/parseMetricValue";
@@ -1053,6 +1054,10 @@ export default function NagarroClientPage() {
             />
           </motion.div>
         )}
+
+        <motion.div variants={VARIANTS_SECTION} transition={TRANSITION_SECTION}>
+          <RelatedProjects currentId="nagarro-design-leadership" />
+        </motion.div>
 
         {/* Navigation */}
         <motion.section

--- a/app/projects/projects-client.tsx
+++ b/app/projects/projects-client.tsx
@@ -3,7 +3,6 @@
 import { motion } from "motion/react";
 import Link from "next/link";
 import { ScrambleSectionTitle } from "@/components/ui/scramble-section-title";
-import Image from "next/image";
 import { ExternalLink, Github, Calendar, Users } from "lucide-react";
 import {
   Card,
@@ -15,15 +14,8 @@ import {
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
-import {
-  isVideoUrl,
-  isUnicornStudioId,
-  extractUnicornStudioId,
-} from "@/lib/video-utils";
-import { UnicornStudioEmbed } from "@/components/ui/unicorn-studio-embed";
-import { HoverIframe } from "@/components/ui/hover-iframe";
-import { HoverVideo } from "@/components/ui/hover-video";
 import { PROJECTS } from "@/lib/data/projects";
+import { ProjectThumbnail } from "@/components/projects/project-thumbnail";
 import { cn } from "@/lib/utils";
 
 const VARIANTS_CONTAINER = {
@@ -46,121 +38,6 @@ const VARIANTS_ITEM = {
     },
   },
 };
-
-function ProjectThumbnail({ project }: { project: (typeof PROJECTS)[0] }) {
-  // Special handling for Nagarro project - always show the logo
-  if (
-    project.slug === "nagarro" &&
-    project.thumbnail?.includes("nagarro-logo.png")
-  ) {
-    return (
-      <div className="aspect-video overflow-hidden">
-        <Image
-          src={project.thumbnail}
-          alt={`${project.name} - ${project.subtitle || project.description} showcasing ${project.technologies.slice(0, 3).join(", ")} implementation`}
-          width={500}
-          height={300}
-          sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
-          className="h-full w-full object-cover transition-transform duration-300 group-hover:scale-105"
-        />
-      </div>
-    );
-  }
-
-  // Check for UnicornStudio content first (highest priority)
-  const unicornVideoId = isUnicornStudioId(project.video)
-    ? extractUnicornStudioId(project.video)
-    : null;
-  const unicornThumbnailId = isUnicornStudioId(project.thumbnail || "")
-    ? extractUnicornStudioId(project.thumbnail || "")
-    : null;
-  const unicornId = unicornVideoId || unicornThumbnailId;
-
-  // Check for local MP4 files (second priority)
-  const isLocalMp4Video =
-    project.video &&
-    project.video.includes(".mp4") &&
-    project.video.startsWith("/");
-  const isLocalMp4Thumbnail =
-    project.thumbnail &&
-    project.thumbnail.includes(".mp4") &&
-    project.thumbnail.startsWith("/");
-
-  // Check for external video URLs (third priority)
-  const videoSrc = isVideoUrl(project.video) ? project.video : null;
-  const thumbnailSrc = isVideoUrl(project.thumbnail || "")
-    ? project.thumbnail
-    : null;
-
-  const staticThumbnail =
-    !isVideoUrl(project.thumbnail || "") &&
-    !isUnicornStudioId(project.thumbnail || "") &&
-    !isLocalMp4Thumbnail &&
-    project.thumbnail
-      ? project.thumbnail
-      : "/images/projects/placeholder-thumbnail.jpg";
-
-  // Priority: UnicornStudio > Local MP4 > External Video > Static thumbnail
-  if (unicornId) {
-    return (
-      <div className="aspect-video overflow-hidden">
-        <UnicornStudioEmbed
-          projectId={unicornId}
-          width={1920}
-          height={1080}
-          className="h-full w-full transition-transform duration-300 group-hover:scale-105"
-        />
-      </div>
-    );
-  }
-
-  // Handle local MP4 files with HoverVideo
-  const localMp4Src = isLocalMp4Thumbnail
-    ? project.thumbnail
-    : isLocalMp4Video
-      ? project.video
-      : null;
-  if (localMp4Src) {
-    return (
-      <div className="aspect-video overflow-hidden">
-        <HoverVideo
-          src={localMp4Src}
-          alt={`${project.name} - ${project.subtitle || project.description} showcasing ${project.technologies.slice(0, 3).join(", ")} implementation`}
-          className="h-full w-full transition-transform duration-300 group-hover:scale-105"
-          resetOnLeave={true}
-          projectName={project.name}
-        />
-      </div>
-    );
-  }
-
-  // Handle external video URLs with HoverIframe
-  const displaySrc = videoSrc || thumbnailSrc;
-  if (displaySrc) {
-    return (
-      <div className="aspect-video overflow-hidden">
-        <HoverIframe
-          src={displaySrc}
-          title={project.name}
-          className="h-full w-full transition-transform duration-300 group-hover:scale-105"
-        />
-      </div>
-    );
-  }
-
-  return (
-    <div className="aspect-video overflow-hidden">
-      <Image
-        src={staticThumbnail}
-        alt={`${project.name} - ${project.subtitle || project.description} showcasing ${project.technologies.slice(0, 3).join(", ")} implementation`}
-        width={500}
-        height={300}
-        sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
-        className="h-full w-full object-cover transition-transform duration-300 group-hover:scale-105"
-      />
-    </div>
-  );
-}
 
 export default function ProjectsClient() {
   return (

--- a/app/projects/rambis-ui/rambis-client.tsx
+++ b/app/projects/rambis-ui/rambis-client.tsx
@@ -19,6 +19,7 @@ import Link from "next/link";
 import { PROJECTS } from "@/lib/data/projects";
 import { CaseStudyNarrative } from "@/components/case-study/case-study-narrative";
 import { ReflectionBlock } from "@/components/case-study/reflection-block";
+import { RelatedProjects } from "@/components/case-study/related-projects";
 
 // Get the Rambis UI project data
 const rambisProject = PROJECTS.find((p) => p.id === "rambis-ui")!;
@@ -393,6 +394,8 @@ export default function RambisClientPage() {
           heading="Reflection"
         />
       )}
+
+      <RelatedProjects currentId="rambis-ui" />
 
       {/* Navigation */}
       <section className="border-t border-zinc-200 pt-8 dark:border-zinc-700">

--- a/app/projects/waffle/waffle-client.tsx
+++ b/app/projects/waffle/waffle-client.tsx
@@ -5,6 +5,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import Link from "next/link";
 import Image from "next/image";
+import { RelatedProjects } from "@/components/case-study/related-projects";
 import { trackEvent } from "@/lib/analytics";
 import {
   MessageSquare,
@@ -336,6 +337,8 @@ export default function WaffleClientPage() {
           ))}
         </div>
       </section>
+
+      <RelatedProjects currentId="waffle" />
 
       {/* Closing CTA band */}
       <section className="rounded-2xl bg-zinc-50 p-8 dark:bg-zinc-900/50">

--- a/components/case-study/related-projects.tsx
+++ b/components/case-study/related-projects.tsx
@@ -1,0 +1,103 @@
+import Link from "next/link";
+import { ArrowRight } from "lucide-react";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { ScrambleSectionTitle } from "@/components/ui/scramble-section-title";
+import { ProjectThumbnail } from "@/components/projects/project-thumbnail";
+import { PROJECTS } from "@/lib/data/projects";
+import type { Project } from "@/lib/data/types";
+
+/**
+ * Pick projects to show alongside the current one: same category first, then
+ * backfill with the remaining featured projects so a page never ends on an
+ * empty "Related Projects" block. Order within each tier follows PROJECTS.
+ */
+export function getRelatedProjects(currentId: string, count = 2): Project[] {
+  const current = PROJECTS.find((p) => p.id === currentId);
+  const others = PROJECTS.filter((p) => p.id !== currentId && !p.archived);
+  const sameCategory = current
+    ? others.filter((p) => p.category === current.category)
+    : [];
+  const rest = others.filter((p) => !sameCategory.includes(p));
+  return [...sameCategory, ...rest].slice(0, count);
+}
+
+type RelatedProjectsProps = {
+  currentId: string;
+  count?: number;
+  heading?: string;
+  sectionId?: string;
+};
+
+/**
+ * "Related Projects" — rendered at the foot of every individual project page,
+ * both the shared [slug] template and the bespoke routes, so the component set
+ * stays identical across all of them (Phase 9 cross-surface consistency).
+ * Cards reuse ProjectThumbnail so a project's preview media is the same here
+ * as on the /projects grid.
+ */
+export function RelatedProjects({
+  currentId,
+  count = 2,
+  heading = "Related Projects",
+  sectionId = "related-projects",
+}: RelatedProjectsProps) {
+  const related = getRelatedProjects(currentId, count);
+  if (related.length === 0) return null;
+
+  const headingId = `${sectionId}-heading`;
+
+  return (
+    <section
+      id={sectionId}
+      role="region"
+      aria-labelledby={headingId}
+      className="space-y-6"
+    >
+      <ScrambleSectionTitle
+        as="h2"
+        id={headingId}
+        className="text-2xl font-bold"
+      >
+        {heading}
+      </ScrambleSectionTitle>
+      <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
+        {related.map((project) => (
+          <Card
+            key={project.id}
+            className="group flex h-full flex-col gap-0 overflow-hidden p-0 transition-all duration-300 hover:shadow-lg"
+          >
+            <Link
+              href={`/projects/${project.slug}`}
+              className="block"
+              aria-label={`${project.name} case study`}
+              tabIndex={-1}
+            >
+              <ProjectThumbnail project={project} />
+            </Link>
+            <CardHeader className="px-4 pt-4 pb-3">
+              <CardTitle className="group-hover:text-primary transition-colors">
+                {project.name}
+              </CardTitle>
+              <CardDescription>{project.description}</CardDescription>
+            </CardHeader>
+            <CardContent className="mt-auto px-4 pt-0 pb-4">
+              <Button asChild className="w-full">
+                <Link href={`/projects/${project.slug}`}>
+                  View Project
+                  <ArrowRight className="ml-2 h-4 w-4" aria-hidden="true" />
+                </Link>
+              </Button>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/components/projects/project-thumbnail.tsx
+++ b/components/projects/project-thumbnail.tsx
@@ -1,0 +1,140 @@
+"use client";
+
+import Image from "next/image";
+import {
+  isVideoUrl,
+  isUnicornStudioId,
+  extractUnicornStudioId,
+} from "@/lib/video-utils";
+import { UnicornStudioEmbed } from "@/components/ui/unicorn-studio-embed";
+import { HoverIframe } from "@/components/ui/hover-iframe";
+import { HoverVideo } from "@/components/ui/hover-video";
+import type { Project } from "@/lib/data/types";
+
+/**
+ * The project card thumbnail used on the /projects grid and in Related
+ * Projects. One component so every surface picks the same media for a
+ * project — UnicornStudio embed, hover video, external iframe, or a static
+ * image — with the same fallbacks.
+ */
+const PLACEHOLDER_THUMBNAIL = "/images/projects/placeholder-thumbnail.jpg";
+
+export function ProjectThumbnail({ project }: { project: Project }) {
+  // Special handling for Nagarro project - always show the logo
+  if (
+    project.slug === "nagarro" &&
+    project.thumbnail?.includes("nagarro-logo.png")
+  ) {
+    return (
+      <div className="aspect-video overflow-hidden">
+        <Image
+          src={project.thumbnail}
+          alt={`${project.name} - ${project.subtitle || project.description} showcasing ${project.technologies.slice(0, 3).join(", ")} implementation`}
+          width={500}
+          height={300}
+          sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
+          className="h-full w-full object-cover transition-transform duration-300 group-hover:scale-105"
+        />
+      </div>
+    );
+  }
+
+  // Check for UnicornStudio content first (highest priority)
+  const unicornVideoId = isUnicornStudioId(project.video)
+    ? extractUnicornStudioId(project.video)
+    : null;
+  const unicornThumbnailId = isUnicornStudioId(project.thumbnail || "")
+    ? extractUnicornStudioId(project.thumbnail || "")
+    : null;
+  const unicornId = unicornVideoId || unicornThumbnailId;
+
+  // Check for local MP4 files (second priority)
+  const isLocalMp4Video =
+    project.video &&
+    project.video.includes(".mp4") &&
+    project.video.startsWith("/");
+  const isLocalMp4Thumbnail =
+    project.thumbnail &&
+    project.thumbnail.includes(".mp4") &&
+    project.thumbnail.startsWith("/");
+
+  // Check for external video URLs (third priority)
+  const videoSrc = isVideoUrl(project.video) ? project.video : null;
+  const thumbnailSrc = isVideoUrl(project.thumbnail || "")
+    ? project.thumbnail
+    : null;
+
+  const staticThumbnail =
+    !isVideoUrl(project.thumbnail || "") &&
+    !isUnicornStudioId(project.thumbnail || "") &&
+    !isLocalMp4Thumbnail &&
+    project.thumbnail
+      ? project.thumbnail
+      : PLACEHOLDER_THUMBNAIL;
+
+  // Priority: UnicornStudio > Local MP4 > External Video > Static thumbnail
+  if (unicornId) {
+    return (
+      <div className="aspect-video overflow-hidden">
+        <UnicornStudioEmbed
+          projectId={unicornId}
+          width={1920}
+          height={1080}
+          className="h-full w-full transition-transform duration-300 group-hover:scale-105"
+        />
+      </div>
+    );
+  }
+
+  // Handle local MP4 files with HoverVideo
+  const localMp4Src = isLocalMp4Thumbnail
+    ? project.thumbnail
+    : isLocalMp4Video
+      ? project.video
+      : null;
+  if (localMp4Src) {
+    return (
+      <div className="aspect-video overflow-hidden">
+        <HoverVideo
+          src={localMp4Src}
+          poster={
+            staticThumbnail !== PLACEHOLDER_THUMBNAIL
+              ? staticThumbnail
+              : undefined
+          }
+          alt={`${project.name} - ${project.subtitle || project.description} showcasing ${project.technologies.slice(0, 3).join(", ")} implementation`}
+          className="h-full w-full transition-transform duration-300 group-hover:scale-105"
+          resetOnLeave={true}
+          projectName={project.name}
+        />
+      </div>
+    );
+  }
+
+  // Handle external video URLs with HoverIframe
+  const displaySrc = videoSrc || thumbnailSrc;
+  if (displaySrc) {
+    return (
+      <div className="aspect-video overflow-hidden">
+        <HoverIframe
+          src={displaySrc}
+          title={project.name}
+          className="h-full w-full transition-transform duration-300 group-hover:scale-105"
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div className="aspect-video overflow-hidden">
+      <Image
+        src={staticThumbnail}
+        alt={`${project.name} - ${project.subtitle || project.description} showcasing ${project.technologies.slice(0, 3).join(", ")} implementation`}
+        width={500}
+        height={300}
+        sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
+        className="h-full w-full object-cover transition-transform duration-300 group-hover:scale-105"
+      />
+    </div>
+  );
+}

--- a/components/ui/tabs.tsx
+++ b/components/ui/tabs.tsx
@@ -42,7 +42,7 @@ function TabsTrigger({
     <TabsPrimitive.Trigger
       data-slot="tabs-trigger"
       className={cn(
-        "data-[state=active]:bg-background dark:data-[state=active]:text-foreground focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:outline-ring dark:data-[state=active]:border-input dark:data-[state=active]:bg-input/30 text-foreground dark:text-muted-foreground inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-2 py-1 text-sm font-medium whitespace-nowrap transition-[color,box-shadow] focus-visible:ring-[3px] focus-visible:outline-1 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:shadow-sm [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "data-[state=inactive]:hover:bg-background/60 data-[state=inactive]:hover:text-foreground dark:data-[state=inactive]:hover:bg-input/20 data-[state=active]:bg-background dark:data-[state=active]:text-foreground focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:outline-ring dark:data-[state=active]:border-input dark:data-[state=active]:bg-input/30 text-foreground dark:text-muted-foreground inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-2 py-1 text-sm font-medium whitespace-nowrap transition-[color,box-shadow] focus-visible:ring-[3px] focus-visible:outline-1 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:shadow-sm [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className,
       )}
       {...props}


### PR DESCRIPTION
## Summary

Two commits pushed to `gsd/phase-09-composite-disclosure` after #51 merged, so they never reached `main`. This PR lands them.

### 1. `f10d787` — define the shadcn design tokens (they never existed)

Every shadcn/ui component on the site is styled with `bg-primary`, `bg-muted`, `text-muted-foreground`, `bg-accent`, `bg-card`, `bg-background`… **None of those utilities existed in the generated CSS.** `tailwind.config.js` maps them to `hsl(var(--primary))` etc., but Tailwind v4 (`@import "tailwindcss"`) doesn't load that file, and the `--primary` / `--muted` / `--accent` variables were defined nowhere in the repo's history.

Visible in production until now: primary buttons rendered with **no fill** (white text on nothing), default/secondary badges were plain text, `bg-primary/10` icon circles were invisible, `hover:bg-accent` was a no-op, and every `text-muted-foreground` inherited full-contrast body colour.

Adds `:root` / `.dark` token sets (shadcn **zinc** preset, matching the zinc utilities the site is otherwise hand-written in) plus the `@theme inline` bridge. **Site-wide visual change by design** — kept as its own commit so it can be reverted in one step if the look needs tuning.

### 2. `145565f` — /projects/addvanced design feedback + shared Related Projects

- Key Achievements: 7 cards centred/equal-height instead of a 4-col grid with a hole
- Usability methodology → 2×2
- Icon circles applied consistently (the 94% card's circle *existed* — it was invisible because of #1)
- Tabs: hover state on inactive triggers (shared `TabsTrigger`)
- **Related Projects** on all 8 project pages via a new shared component; `[slug]` template's inline block replaced by it
- `ProjectThumbnail` extracted to `components/projects/` and shared; hover-video cards now get a poster so they paint immediately
- Waffle thumbnail test updated (was asserting the old `screenshot.png`)

## Test plan
- [x] `npx tsc --noEmit`, `npm run lint` clean
- [x] `npm test` — 1166 pass (only the documented jsdom FPS flake)
- [x] Visual check light + dark on /projects/addvanced and /projects/ledgeriq (before/after)
- [ ] Eyeball a couple of pages after deploy — buttons now filled, badges now pills, secondary text now gray

🤖 Generated with [Claude Code](https://claude.com/claude-code)