### PR TITLE
feat(header): update tagline to "Design-led, end to end."

### DIFF
--- a/__tests__/ui/header-layout-professional.test.tsx
+++ b/__tests__/ui/header-layout-professional.test.tsx
@@ -79,7 +79,7 @@ describe("Professional Header Layout (TDD RED Phase)", () => {
       // Should have left column (name + subtitle)
       expect(screen.getByText("Randy Ellis")).toBeInTheDocument();
       expect(
-        screen.getByText("Taste, made executable."),
+        screen.getByText("Design-led, end to end."),
       ).toBeInTheDocument();
 
       // Should have right column (navigation only)

--- a/app/header.tsx
+++ b/app/header.tsx
@@ -58,7 +58,7 @@ export function Header() {
             className="whitespace-nowrap text-zinc-600 dark:text-zinc-500"
             delay={0.5}
           >
-            Taste, made executable.
+            Design-led, end to end.
           </TextEffect>
         </div>
       </header>


### PR DESCRIPTION
## Summary

Replaces the sitewide header tagline below "Randy Ellis".

**Before:** `Taste, made executable.`
**After:** `Design-led, end to end.`

The new line frames the header around the client outcome rather than a craft claim.

## Changes

| File | Change |
| --- | --- |
| `app/header.tsx:61` | The rendered tagline |
| `__tests__/ui/header-layout-professional.test.tsx:82` | Matching `getByText` assertion |

## Notes on the wording

Two constraints shaped the specific line:

- **Layout.** The tagline is `whitespace-nowrap`, so it cannot wrap. The new line is 23 characters — identical to the previous one — so the header layout is unchanged at every breakpoint.
- **No duplication with the hero.** `Header` renders sitewide via `app/layout.tsx:124`, placing this line directly above the homepage hero, which already reads *"I turn startups into design-led organizations — and write the code to prove it."* Candidate wordings that restated that outcome in the first person were rejected to avoid saying the same sentence twice within one viewport.

`.planning/.continue-here.md` mentions the old tagline in a dated changelog entry. That is a historical record of a past change, so it was intentionally left as-is.

## Verification

All three gates from `CLAUDE.md` run clean:

```
npm test -- __tests__/ui/header-layout-professional.test.tsx   14 passed, 14 total
npm run lint                                                   No ESLint warnings or errors
npx tsc --noEmit                                               exit 0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PRMzE9k67UcjY49FGh1s2Q

---
_Generated by [Claude Code](https://claude.ai/code/session_01PRMzE9k67UcjY49FGh1s2Q)_